### PR TITLE
Fix failed CI building

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,13 @@
         "ramsey/uuid": "^3.9",
         "react/event-loop": "^1.1",
         "react/socket": "^1.3",
-        "symfony/console": "^5.0"
+        "symfony/console": "^4.3 || ^5.0"
     },
     "require-dev" : {
         "phpunit/phpunit": "^8.2",
         "seregazhuk/php-watcher": "^0.5.2",
-        "symfony/process": "^5.0",
-        "symfony/var-dumper": "^5.0"
+        "symfony/process": "^4.3 || ^5.0",
+        "symfony/var-dumper": "^4.3 || ^5.0"
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
# Changed log

- Fix CI building to resolve following issue:

```
  Problem 1
    - laravel/framework[v6.0.0, ..., v6.20.15] require symfony/var-dumper ^4.3.4 -> found symfony/var-dumper[v4.3.4, ..., v4.4.18] but it conflicts with your root composer.json require (^5.0).
    - Root composer.json requires laravel/framework 6.* -> satisfiable by laravel/framework[v6.0.0, ..., v6.20.15].

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

```